### PR TITLE
Test for xSQLServerPermission

### DIFF
--- a/DSCResources/xSQLServerPermission/xSQLServerPermission.schema.mof
+++ b/DSCResources/xSQLServerPermission/xSQLServerPermission.schema.mof
@@ -6,6 +6,6 @@ class xSQLServerPermission : OMI_BaseResource
     [Required, Description("The host name or FQDN.")] String NodeName;
     [Write, Description("If the permission should be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Required, Description("The login to which permission will be set.")] String Principal;
-    [Write, Description("The permission to set for the login."), ValueMap{"ALTER ANY AVAILABILITY GROUP","VIEW SERVER STATE","ALTER ANY ENDPOINT"}, Values{"ALTER ANY AVAILABILITY GROUP","VIEW SERVER STATE","ALTER ANY ENDPOINT"}] String Permission[];
+    [Write, Description("The permission to set for the login."), ValueMap{"AlterAnyAvailabilityGroup","ViewServerState","AlterAnyEndPoint"}, Values{"AlterAnyAvailabilityGroup","ViewServerState","AlterAnyEndPoint"}] String Permission[];
 };
 

--- a/Tests/Unit/Stubs/SMO.cs
+++ b/Tests/Unit/Stubs/SMO.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.SqlServer.Management.Smo
+{
+    // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionSet
+    // BaseType: Microsoft.SqlServer.Management.Smo.PermissionSetBase
+    // Used by: 
+    //  xSQLServerPermission
+    public class ServerPermissionSet 
+    {
+        public ServerPermissionSet(){}
+
+        public ServerPermissionSet(
+            bool alterAnyAvailabilityGroup, 
+            bool alterAnyEndPoint,
+            bool connectSql,  
+            bool viewServerState )
+        {
+            this.AlterAnyAvailabilityGroup = alterAnyAvailabilityGroup; 
+            this.AlterAnyEndPoint = alterAnyEndPoint;
+            this.ConnectSql = connectSql;
+            this.ViewServerState = viewServerState;
+        } 
+    
+        public bool AlterAnyAvailabilityGroup = false;
+        public bool AlterAnyEndPoint = false;
+        public bool ConnectSql = false;
+        public bool ViewServerState = false;
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.ServerPermissionInfo
+    // BaseType: Microsoft.SqlServer.Management.Smo.PermissionInfo
+    // Used by: 
+    //  xSQLServerPermission
+    public class ServerPermissionInfo 
+    {
+        public ServerPermissionInfo()
+        {
+            Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = { new Microsoft.SqlServer.Management.Smo.ServerPermissionSet() };
+            this.PermissionType = permissionSet;
+        }
+
+        public ServerPermissionInfo( 
+            Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet )
+        {
+            this.PermissionType = permissionSet;
+        }
+        
+        public Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] PermissionType;
+        public string PermissionState = "Grant";
+    }
+
+    // TypeName: Microsoft.SqlServer.Management.Smo.Server
+    // BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
+    // Used by: 
+    //  xSQLServerPermission
+    public class Server 
+    { 
+        private bool _generateMockData = false;
+
+        public string MockGranteeName;
+
+        public string Name;
+        public string DisplayName;
+        public string InstanceName;
+        public bool IsHadrEnabled = false;
+
+        public Server()
+        { 
+            _generateMockData = false;
+        } 
+
+        public Server( bool generateMockData )
+        { 
+            this._generateMockData = generateMockData;
+        } 
+
+        public Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] EnumServerPermissions( string principal, Microsoft.SqlServer.Management.Smo.ServerPermissionSet permissionSetQuery ) 
+        { 
+            List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo> listOfServerPermissionInfo = new List<Microsoft.SqlServer.Management.Smo.ServerPermissionInfo>();
+            
+            if( this._generateMockData ) {
+                Microsoft.SqlServer.Management.Smo.ServerPermissionSet[] permissionSet = { 
+                    new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( true, false, false, false ),
+                    new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, true, false, false ),
+                    new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, false, true, false ),
+                    new Microsoft.SqlServer.Management.Smo.ServerPermissionSet( false, false, false, true ) };
+
+                listOfServerPermissionInfo.Add( new Microsoft.SqlServer.Management.Smo.ServerPermissionInfo( permissionSet ) );
+            } else {
+                listOfServerPermissionInfo.Add( new Microsoft.SqlServer.Management.Smo.ServerPermissionInfo() );
+            }
+
+            Microsoft.SqlServer.Management.Smo.ServerPermissionInfo[] permissionInfo = listOfServerPermissionInfo.ToArray();
+
+            return permissionInfo;
+        }
+
+        public void Grant( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
+        {
+            if( granteeName != this.MockGranteeName ) 
+            {
+                string errorMessage = "Expected to get granteeName == '" + this.MockGranteeName + "'. But got '" + granteeName + "'";
+                throw new System.ArgumentException(errorMessage, "granteeName");
+            }
+        }
+
+        public void Revoke( Microsoft.SqlServer.Management.Smo.ServerPermissionSet permission, string granteeName )
+        {
+
+        }
+    }
+}

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -12,6 +12,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
@@ -26,158 +27,160 @@ try
 {
     #region Pester Test Initialization
 
-    # TODO: Optionally create any variables here for use by your tests
+    # Loading mocked classes
+    Add-Type -Path (Join-Path -Path $script:moduleRoot -ChildPath 'Tests\Unit\Stubs\SMO.cs')
+
     $nodeName = 'localhost'
     $instanceName = 'DEFAULT'
-
-    # See https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
-    # Mocks that should be applied to all cmdlets being tested may
-    # also be created here if required.
+    $principal = 'COMPANY\SqlServiceAcct'
+    $permission = @( 'AlterAnyAvailabilityGroup','ViewServerState' )
 
     #endregion Pester Test Initialization
 
-    # TODO: Common DSC Resource describe block structure
-    # The following three Describe blocks are included as a common test pattern.
-    # If a different test pattern would be more suitable, then test describe blocks
-    # may be completely replaced. The goal of this pattern should be to describe 
-    # the potential states a system could be in so that the get/test/set cmdlets
-    # can be tested in those states. Any mocks that relate to that specific state
-    # can be included in the relevant describe block. For a more detailed description
-    # of this approach please review https://github.com/PowerShell/DscResources/issues/143 
-
-    # Add as many of these example 'states' as required to simulate the scenarions that
-    # the DSC resource is designed to work with, below a simple "is in desired state" and
-    # "is not in desired state" are used, but there may be more complex combinations of 
-    # factors, depending on how complex your resource is.
-
-    #region Example state 1
     Describe 'The system is not in the desired state' {
-        #TODO: Mock cmdlets here that represent the system not being in the desired state
-        
-        # http://windowsitpro.com/powershell/powershell-basics-custom-objects
-        # https://social.technet.microsoft.com/wiki/contents/articles/7804.powershell-creating-custom-objects.aspx
-        
-        # TypeName: Microsoft.SqlServer.Management.Smo.Server
-        # BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
-        
-        #START Using this requires V5
-        Class SqlSmoObject { 
-            [string] $name; 
-         
-            SqlSmoObject([string] $NameIn) { 
-                $this.name = $NameIn; 
-            } 
+        Mock -CommandName Get-SQLPSInstance -MockWith { 
+            $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @( $false )
+            $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+            $mockObjectSmoServer.DisplayName = $instanceName
+            $mockObjectSmoServer.InstanceName = $instanceName
+            $mockObjectSmoServer.IsHadrEnabled = $False
+            $mockObjectSmoServer.MockGranteeName = $principal
 
-            [string] EnumServerPermissions() { 
-                #$a = $null 
-                #[char[]]$this.Name | Sort-Object {Get-Random} | %{ $a = $PSItem + $a} 
-                return "Hejdå ($name)" 
-            } 
-        } 
-
-        $x = [SqlSmoObject]::new("Microsoft.SqlServer.Management.Smo.Server") 
-        $x.EnumServerPermissions() 
-        #END Using this requires V5
-
-        #region Mock Microsoft.SqlServer.Management.Smo.Server
-        $mockObjectSmoServer = [PSCustomObject] @{
-            Name = "$nodeName\$instanceName"
-            DisplayName = $instanceName
-            InstanceName = $instanceName
-            IsHadrEnabled = $False
-        }
-
-        $mockMethodEnumServerPermissions = @{
-            Name = 'EnumServerPermissions'
-            MemberType = 'ScriptMethod'
-            Value = {  
-                "Hejdå"
-            }
-        }
-
-        $mockObjectSmoServer.PSTypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
-        $mockObjectSmoServer | Add-Member @mockMethodEnumServerPermissions
-        #endregion Mock Microsoft.SqlServer.Management.Smo.Server
-
-        $TestNetIPInterfaceEnabled = [PSObject]@{
-            State                   = 'Enabled'
-            InterfaceAlias          = $MockNetAdapter.Name
-            AddressFamily           = 'IPv4'
-        }
-
-        Mock Get-SQLPSInstance -MockWith { $MockNetAdapter }
-
-        #TODO: Create a set of parameters to test your get/test/set methods in this state
+            return $mockObjectSmoServer
+        } -ModuleName $script:DSCResourceName -Verifiable
+ 
         $testParameters = @{
-            InstanceName = 'localhost'
-            NodeName = 'MSSQLSERVER'
-            Principal = 'COMPANY\DummyAccount'
-            Permission = @('ALTER ANY AVAILABILITY GROUP','VIEW SERVER STATE')
+            InstanceName = $instanceName
+            NodeName = $nodeName
+            Principal = $principal
+            Permission = $permission
         }
 
-        #TODO: Update the assertions below to align with the expected results of this state
+        $result = Get-TargetResource @testParameters
+
         It 'Get method returns desired state is absent' {
-            $result = Get-TargetResource @testParameters
             $result.Ensure | Should Be 'Absent'
         }
 
-        $testParameters = @{
+        It 'Get method returns correct node name' {
+            $result.NodeName | Should Be $nodeName
+        }
+
+        It 'Get method returns correct instance name' {
+            $result.InstanceName | Should Be $instanceName
+        }
+
+        It 'Get method returns correct principal' {
+            $result.Principal | Should Be $principal
+        }
+
+        It 'Get method returns no permissions' {
+            $result.Permission | Should Be $null
+        }
+
+        $testParameters += @{
             Ensure = 'Present'
         }
 
-        It 'Test method returns false' {
-            Test-TargetResource @testParameters | Should be $false
+        $result = Test-TargetResource @testParameters
+
+        It 'Test method returns desired state is absent' {
+            $result | Should Be $false
         }
 
-        It 'Set method calls Demo-CmdletName' {
-            Set-TargetResource @testParameters
-
-            #TODO: Assert that the appropriate cmdlets were called
-            Assert-MockCalled Demo-CmdletName 
+        It 'Set method calls Get-SQLPSInstance' {
+            Assert-MockCalled Get-SQLPSInstance -Exactly -Times 2 -ModuleName $script:DSCResourceName
         }
+
+        It 'Set method should not throw' {
+            { Set-TargetResource @testParameters } | Should Not Throw
+        }
+
+        It 'Get,Test and Set method calls Get-SQLPSInstance' {
+            Assert-MockCalled Get-SQLPSInstance -Exactly 4 -ModuleName $script:DSCResourceName
+        }
+
+        Assert-VerifiableMocks
     }
-    #endregion Example state 1
 
-    #region Example state 2
     Describe 'The system is in the desired state' {
-        #TODO: Mock cmdlets here that represent the system being in the desired state
+        Mock -CommandName Get-SQLPSInstance -MockWith { 
+            $mockObjectSmoServer = New-Object Microsoft.SqlServer.Management.Smo.Server -ArgumentList @($true)
+            $mockObjectSmoServer.Name = "$nodeName\$instanceName"
+            $mockObjectSmoServer.DisplayName = $instanceName
+            $mockObjectSmoServer.InstanceName = $instanceName
+            $mockObjectSmoServer.IsHadrEnabled = $False
+            $mockObjectSmoServer.MockGranteeName = $principal
 
-        #TODO: Create a set of parameters to test your get/test/set methods in this state
+            return $mockObjectSmoServer
+        } -ModuleName $script:DSCResourceName -Verifiable
+
         $testParameters = @{
-            Property1 = 'value'
-            Property2 = 'value'
+            InstanceName = $instanceName
+            NodeName = $nodeName
+            Principal = $principal
+            Permission = $permission
         }
 
-        #TODO: Update the assertions below to align with the expected results of this state
-        It 'Get method returns something' {
-            Get-TargetResource @testParameters | Should Be 'something'
+        $result = Get-TargetResource @testParameters
+
+        It 'Get method returns desired state is present' {
+            $result.Ensure | Should Be 'Present'
         }
 
-        It 'Test method returns true' {
-            Test-TargetResource @testParameters | Should be $true
+        It 'Get method returns correct node name' {
+            $result.NodeName | Should Be $nodeName
         }
+
+        It 'Get method returns correct instance name' {
+            $result.InstanceName | Should Be $instanceName
+        }
+
+        It 'Get method returns correct principal' {
+            $result.Principal | Should Be $principal
+        }
+
+        It 'Get method returns correct permissions' {
+            foreach ($currentPermission in $permission) {
+                if( $result.Permission -ccontains $currentPermission ) {
+                    $permissionState = $true 
+                } else {
+                    $permissionState = $false
+                    break
+                }
+            } 
+            
+            $permissionState | Should Be $true
+        }
+
+        $testParameters += @{
+            Ensure = 'Present'
+        }
+
+        $result = Test-TargetResource @testParameters
+        
+        It 'Test method returns desired state is present' {
+            $result | Should Be $true
+        }
+
+        It 'Set method should not throw' {
+            { Set-TargetResource @testParameters } | Should Not Throw
+        }
+
+        It 'Get,Test and Set method calls Get-SQLPSInstance' {
+            Assert-MockCalled Get-SQLPSInstance -Exactly 3 -ModuleName $script:DSCResourceName
+        }
+
+        Assert-VerifiableMocks
     }
-    #endregion Example state 1
-
-    #region Non-Exported Function Unit Tests
-
-    # TODO: Pester Tests for any non-exported Helper Cmdlets
-    # If the resource does not contain any non-exported helper cmdlets then
-    # this block may be safetly deleted.
-    InModuleScope $script:DSCResourceName {
-        # The InModuleScope command allows you to perform white-box unit testing
-        # on the internal (non-exported) code of a Script Module.
-
-    }
-    #endregion Non-Exported Function Unit Tests
 }
 finally
 {
     #region FOOTER
 
-    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment 
 
     #endregion
 
-    # TODO: Other Optional Cleanup Code Goes Here...
+    Remove-module $script:DSCResourceName -Force
 }

--- a/Tests/Unit/xSQLServerPermission.Tests.ps1
+++ b/Tests/Unit/xSQLServerPermission.Tests.ps1
@@ -1,0 +1,183 @@
+$script:DSCModuleName      = 'xSQLServer'
+$script:DSCResourceName    = 'xSQLServerPermission'
+
+#region HEADER
+
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit 
+
+#endregion HEADER
+
+# TODO: Other Optional Init Code Goes Here...
+
+# Begin Testing
+try
+{
+    #region Pester Test Initialization
+
+    # TODO: Optionally create any variables here for use by your tests
+    $nodeName = 'localhost'
+    $instanceName = 'DEFAULT'
+
+    # See https://github.com/PowerShell/xNetworking/blob/dev/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+    # Mocks that should be applied to all cmdlets being tested may
+    # also be created here if required.
+
+    #endregion Pester Test Initialization
+
+    # TODO: Common DSC Resource describe block structure
+    # The following three Describe blocks are included as a common test pattern.
+    # If a different test pattern would be more suitable, then test describe blocks
+    # may be completely replaced. The goal of this pattern should be to describe 
+    # the potential states a system could be in so that the get/test/set cmdlets
+    # can be tested in those states. Any mocks that relate to that specific state
+    # can be included in the relevant describe block. For a more detailed description
+    # of this approach please review https://github.com/PowerShell/DscResources/issues/143 
+
+    # Add as many of these example 'states' as required to simulate the scenarions that
+    # the DSC resource is designed to work with, below a simple "is in desired state" and
+    # "is not in desired state" are used, but there may be more complex combinations of 
+    # factors, depending on how complex your resource is.
+
+    #region Example state 1
+    Describe 'The system is not in the desired state' {
+        #TODO: Mock cmdlets here that represent the system not being in the desired state
+        
+        # http://windowsitpro.com/powershell/powershell-basics-custom-objects
+        # https://social.technet.microsoft.com/wiki/contents/articles/7804.powershell-creating-custom-objects.aspx
+        
+        # TypeName: Microsoft.SqlServer.Management.Smo.Server
+        # BaseType: Microsoft.SqlServer.Management.Smo.SqlSmoObject
+        
+        #START Using this requires V5
+        Class SqlSmoObject { 
+            [string] $name; 
+         
+            SqlSmoObject([string] $NameIn) { 
+                $this.name = $NameIn; 
+            } 
+
+            [string] EnumServerPermissions() { 
+                #$a = $null 
+                #[char[]]$this.Name | Sort-Object {Get-Random} | %{ $a = $PSItem + $a} 
+                return "Hejdå ($name)" 
+            } 
+        } 
+
+        $x = [SqlSmoObject]::new("Microsoft.SqlServer.Management.Smo.Server") 
+        $x.EnumServerPermissions() 
+        #END Using this requires V5
+
+        #region Mock Microsoft.SqlServer.Management.Smo.Server
+        $mockObjectSmoServer = [PSCustomObject] @{
+            Name = "$nodeName\$instanceName"
+            DisplayName = $instanceName
+            InstanceName = $instanceName
+            IsHadrEnabled = $False
+        }
+
+        $mockMethodEnumServerPermissions = @{
+            Name = 'EnumServerPermissions'
+            MemberType = 'ScriptMethod'
+            Value = {  
+                "Hejdå"
+            }
+        }
+
+        $mockObjectSmoServer.PSTypeNames.Insert(0,'Microsoft.SqlServer.Management.Smo.Server')
+        $mockObjectSmoServer | Add-Member @mockMethodEnumServerPermissions
+        #endregion Mock Microsoft.SqlServer.Management.Smo.Server
+
+        $TestNetIPInterfaceEnabled = [PSObject]@{
+            State                   = 'Enabled'
+            InterfaceAlias          = $MockNetAdapter.Name
+            AddressFamily           = 'IPv4'
+        }
+
+        Mock Get-SQLPSInstance -MockWith { $MockNetAdapter }
+
+        #TODO: Create a set of parameters to test your get/test/set methods in this state
+        $testParameters = @{
+            InstanceName = 'localhost'
+            NodeName = 'MSSQLSERVER'
+            Principal = 'COMPANY\DummyAccount'
+            Permission = @('ALTER ANY AVAILABILITY GROUP','VIEW SERVER STATE')
+        }
+
+        #TODO: Update the assertions below to align with the expected results of this state
+        It 'Get method returns desired state is absent' {
+            $result = Get-TargetResource @testParameters
+            $result.Ensure | Should Be 'Absent'
+        }
+
+        $testParameters = @{
+            Ensure = 'Present'
+        }
+
+        It 'Test method returns false' {
+            Test-TargetResource @testParameters | Should be $false
+        }
+
+        It 'Set method calls Demo-CmdletName' {
+            Set-TargetResource @testParameters
+
+            #TODO: Assert that the appropriate cmdlets were called
+            Assert-MockCalled Demo-CmdletName 
+        }
+    }
+    #endregion Example state 1
+
+    #region Example state 2
+    Describe 'The system is in the desired state' {
+        #TODO: Mock cmdlets here that represent the system being in the desired state
+
+        #TODO: Create a set of parameters to test your get/test/set methods in this state
+        $testParameters = @{
+            Property1 = 'value'
+            Property2 = 'value'
+        }
+
+        #TODO: Update the assertions below to align with the expected results of this state
+        It 'Get method returns something' {
+            Get-TargetResource @testParameters | Should Be 'something'
+        }
+
+        It 'Test method returns true' {
+            Test-TargetResource @testParameters | Should be $true
+        }
+    }
+    #endregion Example state 1
+
+    #region Non-Exported Function Unit Tests
+
+    # TODO: Pester Tests for any non-exported Helper Cmdlets
+    # If the resource does not contain any non-exported helper cmdlets then
+    # this block may be safetly deleted.
+    InModuleScope $script:DSCResourceName {
+        # The InModuleScope command allows you to perform white-box unit testing
+        # on the internal (non-exported) code of a Script Module.
+
+    }
+    #endregion Non-Exported Function Unit Tests
+}
+finally
+{
+    #region FOOTER
+
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+
+    #endregion
+
+    # TODO: Other Optional Cleanup Code Goes Here...
+}

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -122,7 +122,7 @@ function New-TerminatingError
 
     Write-Verbose -Message "$($USLocalizedData.$ErrorType -f $FormatArgs) | ErrorType: $errorId"
 
-    $exception = New-Object System.Exception $errorMessage;
+    $exception = New-Object System.Exception $errorMessage, $InnerException;    
     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $ErrorCategory, $TargetObject
 
     return $errorRecord

--- a/xSQLServerHelper.psm1
+++ b/xSQLServerHelper.psm1
@@ -122,7 +122,7 @@ function New-TerminatingError
 
     Write-Verbose -Message "$($USLocalizedData.$ErrorType -f $FormatArgs) | ErrorType: $errorId"
 
-    $exception = New-Object System.Exception $errorMessage, $InnerException;    
+    $exception = New-Object System.Exception $errorMessage, $InnerException    
     $errorRecord = New-Object System.Management.Automation.ErrorRecord $exception, $errorId, $ErrorCategory, $TargetObject
 
     return $errorRecord


### PR DESCRIPTION
- Added test for xSQLServerPermission
- Added stub file for mocking SMO
- Fixed New-TerminationError so it uses InnerException more correctly
- Changed xSQLServerPermission so it uses property names in the validate set instead. This was done for the test to work and the benefit was less code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johlju/xsqlserver/1)
<!-- Reviewable:end -->
