### PR TITLE
Fix test for issue 649

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
   - Code style clean-up throughout the module to align against the Style Guideline.
   - Fixed typos and the use of wrong parameters in unit tests which was found
     after release of new version of Pester ([issue #773](https://github.com/PowerShell/xFailOverCluster/issues/773)).
+  - Updated appveyor.yml so that integration tests can run in AppVeyor ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
 - Changes to xSQLServerAlwaysOnService
   - Added resource description in README.md.
   - Updated parameters descriptions in comment-based help, schema.mof and README.md.
@@ -66,6 +67,8 @@
     and no longer throws an error when there is just one Analysis Services
     administrator (issue #691).
   - Added a simple integration test ([issue #709](https://github.com/PowerShell/xSQLServer/issues/709)).
+    - Fixed so that the integration test copies back the SQLPS module
+      ([issue #774](https://github.com/PowerShell/xFailOverCluster/issues/774)).
   - Fixed PS Script Analyzer errors ([issue #729](https://github.com/PowerShell/xSQLServer/issues/729))
 
 ## 8.0.0.0

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -24,6 +24,23 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 #endregion
 
+<#
+    Copies back the SQLPS module that was removed by AppVeyor.yml
+    (see issue #774).
+    SQLPS is removed because otherwise the common test will load
+    the SMO assembly and fail the unit tests (see issue #239)
+#>
+$rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
+$copyItemParameters = @{
+    Path = Join-Path -Path $rootTempPath -ChildPath '*'
+    Destination = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules'
+    Recurse = $true
+    Force = $true
+    Verbose = $true
+}
+
+Copy-Item @copyItemParameters
+
 $mockInstanceName = 'DSCSQL2016'
 $mockFeatures = 'SQLENGINE,CONN,BC,SDK'
 $mockSqlCollation = 'Finnish_Swedish_CI_AS'

--- a/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xSQLServerSetup.Integration.Tests.ps1
@@ -36,7 +36,6 @@ $copyItemParameters = @{
     Destination = 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules'
     Recurse = $true
     Force = $true
-    Verbose = $true
 }
 
 Copy-Item @copyItemParameters

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ test_script:
         Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
         Write-Verbose -Message 'This is a workaround because the integration tests need SQLPS module. More information in issue #774.' -Verbose
         New-Item -Path $rootTempPath -Type Directory | Out-Null
-        Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force -Verbose
+        Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force
 
         Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
         Write-Verbose -Message 'This is a workaround because the AppVeyor build worker image contains SQL Server. More information in issue #239.' -Verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,12 @@ build: false
 
 test_script:
     - ps: |
+        $rootTempPath = Join-Path -Path $env:TEMP -ChildPath 'SqlModuleTemp'
+        Write-Verbose -Message ('Copying the SQLPS module to a temporary location (''{0}'') for later use by integration tests.' -f $rootTempPath) -Verbose
+        Write-Verbose -Message 'This is a workaround because the integration tests need SQLPS module. More information in issue #774.' -Verbose
+        New-Item -Path $rootTempPath -Type Directory | Out-Null
+        Copy-Item -Path 'C:\Program Files (x86)\Microsoft SQL Server\130\Tools\PowerShell\Modules\*' -Destination $rootTempPath -Recurse -Force -Verbose
+
         Write-Verbose -Message 'Removing all SQL related PowerShell modules so they can not be used by the common tests.' -Verbose
         Write-Verbose -Message 'This is a workaround because the AppVeyor build worker image contains SQL Server. More information in issue #239.' -Verbose
         Write-Verbose -Message 'Modules that are being removed:' -Verbose

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,11 @@
 version: 6.0.{build}.0
 image: Visual Studio 2017
 install:
-    - git clone https://github.com/PowerShell/DscResource.Tests
+    - git clone https://github.com/johlju/DscResource.Tests
+    - ps: Push-Location
+    - ps: cd "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests"
+    - git checkout ordered-tests
+    - ps: Pop-Location
     - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
     - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
     - ps: Invoke-AppveyorInstallTask

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ test_script:
         Write-Verbose -Message 'Modules that are being removed:' -Verbose
         Get-Module -ListAvailable -Name 'sql*' | ForEach-Object -Process { Write-Verbose $_.Path -Verbose; Remove-Item $_.Path -Force -Verbose; }
 
-        Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @()
+        Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @() -RunTestInOrder
 
 #---------------------------------#
 #      deployment configuration   #


### PR DESCRIPTION
- Changes to xSQLServer
  - Updated appveyor.yml so that integration tests can run in AppVeyor (issue #774).
- Changes to xSQLServerSetup
  - Fixed so that the integration test copies back the SQLPS module (issue #774).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/johlju/xsqlserver/8)
<!-- Reviewable:end -->
